### PR TITLE
fix: Excon fails with 404 error sending slack post.message API

### DIFF
--- a/lib/fastlane/plugin/slack_bot/actions/post_to_slack.rb
+++ b/lib/fastlane/plugin/slack_bot/actions/post_to_slack.rb
@@ -42,7 +42,7 @@ module Fastlane
           payload[:thread_ts] = options[:thread_ts] unless options[:thread_ts].nil?
           payload = payload.to_json
 
-          response = Excon.post(api_url, headers: headers, body: payload)
+          response = Excon.post(api_url, headers: headers, body: payload, omit_default_port: true)
           result = self.formatted_result(response)
         rescue => exception
           UI.error("Exception: #{exception}")


### PR DESCRIPTION
I think Excon transform the api string from "https://slack.com/api/chat.postMessage" to "https://slack.com:443/api/chat.postMessage" if omit_default_port option is not set.

This action may prevent the Slack API server to route correctly, and responses 404 error.