### PR TITLE
Delete message support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ A fastlane plugin to customize your automation workflow(s) with a **Slack Bot** 
 - [Getting Started](#getting-started)
 - [Features](#features)
 - [Post a message](#examples-post-a-message) examples
+- [Update a message](https://github.com/crazymanish/fastlane-plugin-slack_bot/blob/master/lib/fastlane/plugin/slack_bot/actions/update_slack_message.rb#L115) examples
+- [Delete a message](https://github.com/crazymanish/fastlane-plugin-slack_bot/blob/master/lib/fastlane/plugin/slack_bot/actions/delete_slack_message.rb#L78) examples
 - [Upload a file](#examples-upload-a-message) examples
 - [About Fastlane](#about-fastlane)
 
@@ -57,6 +59,9 @@ Using this `slack_bot` plugin, you can:
 
 - Update a message using [chat.update](https://api.slack.com/methods/chat.update) Slack API
   - [x] update a message in a channel
+
+- Delete a message using [chat.delete](https://api.slack.com/methods/chat.delete) Slack API
+  - [x] delete a message in a channel
 
 - List of files in a channel using [files.list](https://api.slack.com/methods/files.list) Slack API
   - [x] A list of files in a channel, It can be filtered and sliced in various ways.

--- a/lib/fastlane/plugin/slack_bot/actions/delete_slack_message.rb
+++ b/lib/fastlane/plugin/slack_bot/actions/delete_slack_message.rb
@@ -8,8 +8,6 @@ module Fastlane
     end
     class DeleteSlackMessageAction < Action
       def self.run(options)
-        options[:message] = (options[:message].to_s || '').gsub('\n', "\n")
-
         begin
           require 'excon'
 

--- a/lib/fastlane/plugin/slack_bot/actions/delete_slack_message.rb
+++ b/lib/fastlane/plugin/slack_bot/actions/delete_slack_message.rb
@@ -1,0 +1,92 @@
+require 'fastlane/action'
+require_relative '../helper/slack_bot_helper'
+
+module Fastlane
+  module Actions
+    module SharedValues
+      DELETE_SLACK_MESSAGE_RESULT = :DELETE_SLACK_MESSAGE_RESULT
+    end
+    class DeleteSlackMessageAction < Action
+      def self.run(options)
+        options[:message] = (options[:message].to_s || '').gsub('\n', "\n")
+
+        begin
+          require 'excon'
+
+          api_url = "https://slack.com/api/chat.delete"
+          headers = { "Content-Type": "application/json", "Authorization": "Bearer #{options[:api_token]}" }
+          payload = { channel: options[:channel], ts: options[:ts] }.to_json
+
+          response = Excon.post(api_url, headers: headers, body: payload)
+          result = self.formatted_result(response)
+        rescue => exception
+          UI.error("Exception: #{exception}")
+          return nil
+        else
+          UI.success("Successfully deleted the Slack message!")
+          Actions.lane_context[SharedValues::DELETE_SLACK_MESSAGE_RESULT] = result
+          return result
+        end
+      end
+
+      def self.formatted_result(response)
+        result = {
+          status: response[:status],
+          body: response.body || "",
+          json: self.parse_json(response.body) || {}
+        }
+      end
+
+      def self.parse_json(value)
+        require 'json'
+
+        JSON.parse(value)
+      rescue JSON::ParserError
+        nil
+      end
+
+      def self.description
+        "Deleate a slack message using time-stamp(ts) value"
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(key: :api_token,
+                                       env_name: "FL_DELETE_SLACK_MESSAGE_BOT_TOKEN",
+                                       description: "Slack bot Token",
+                                       sensitive: true,
+                                       code_gen_sensitive: true,
+                                       is_string: true,
+                                       default_value: ENV["SLACK_API_TOKEN"],
+                                       default_value_dynamic: true,
+                                       optional: false),
+          FastlaneCore::ConfigItem.new(key: :ts,
+                                       env_name: "FL_DELETE_SLACK_MESSAGE_TS",
+                                       description: "Timestamp of the message to be deleted",
+                                       optional: false),
+          FastlaneCore::ConfigItem.new(key: :channel,
+                                       env_name: "FL_DELETE_SLACK_MESSAGE_CHANNEL",
+                                       description: "Slack channel_id containing the message to be deleted. i.e C1234567890",
+                                       optional: false)
+        ]
+      end
+
+      def self.authors
+        ["crazymanish"]
+      end
+
+      def self.example_code
+        [
+          'delete_slack_message(
+            ts: "1609711037.000100",
+            channel: "C1234567890"
+          )'
+        ]
+      end
+
+      def self.is_supported?(platform)
+        true
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### Motivation:
- Sometimes we have to delete a Slack message because of some X.Y.Z reasons i.e CI failed etc

#### In this PR,
- Introduce the `delete_slack_message` action

#### Example,
```ruby
delete_slack_message(
  ts: "1609711037.000100",
  channel: "C1234567890"
)
```